### PR TITLE
Delay initial system update check

### DIFF
--- a/Common/SettingsData.qml
+++ b/Common/SettingsData.qml
@@ -133,6 +133,7 @@ Singleton {
         saveSettings()
     }
     onNotepadLastCustomTransparencyChanged: saveSettings()
+    onSystemUpdateInitialDelayMsChanged: saveSettings()
     property bool gtkThemingEnabled: false
     property bool qtThemingEnabled: false
     property bool showDock: false
@@ -161,6 +162,7 @@ Singleton {
     property int notificationTimeoutLow: 5000
     property int notificationTimeoutNormal: 5000
     property int notificationTimeoutCritical: 0
+    property int systemUpdateInitialDelayMs: 5000
     property var screenPreferences: ({})
     readonly property string defaultFontFamily: "Inter Variable"
     readonly property string defaultMonoFontFamily: "Fira Code"
@@ -356,6 +358,7 @@ Singleton {
                 notificationTimeoutLow = settings.notificationTimeoutLow !== undefined ? settings.notificationTimeoutLow : 5000
                 notificationTimeoutNormal = settings.notificationTimeoutNormal !== undefined ? settings.notificationTimeoutNormal : 5000
                 notificationTimeoutCritical = settings.notificationTimeoutCritical !== undefined ? settings.notificationTimeoutCritical : 0
+                systemUpdateInitialDelayMs = settings.systemUpdateInitialDelayMs !== undefined ? settings.systemUpdateInitialDelayMs : 5000
                 dankBarSpacing = settings.dankBarSpacing !== undefined ? settings.dankBarSpacing : (settings.topBarSpacing !== undefined ? settings.topBarSpacing : 4)
                 dankBarBottomGap = settings.dankBarBottomGap !== undefined ? settings.dankBarBottomGap : (settings.topBarBottomGap !== undefined ? settings.topBarBottomGap : 0)
                 dankBarInnerPadding = settings.dankBarInnerPadding !== undefined ? settings.dankBarInnerPadding : (settings.topBarInnerPadding !== undefined ? settings.topBarInnerPadding : 4)
@@ -490,6 +493,7 @@ Singleton {
                                                 "notificationTimeoutLow": notificationTimeoutLow,
                                                 "notificationTimeoutNormal": notificationTimeoutNormal,
                                                 "notificationTimeoutCritical": notificationTimeoutCritical,
+                                                "systemUpdateInitialDelayMs": systemUpdateInitialDelayMs,
                                                 "screenPreferences": screenPreferences
                                             }, null, 2))
     }

--- a/Services/SystemUpdateService.qml
+++ b/Services/SystemUpdateService.qml
@@ -53,7 +53,7 @@ Singleton {
             if (exitCode === 0) {
                 const helperPath = stdout.text.trim()
                 pkgManager = helperPath.split('/').pop()
-                checkForUpdates()
+                initialCheckTimer.restart()
             } else {
                 console.warn("SystemUpdate: No package manager found")
             }
@@ -89,7 +89,17 @@ Singleton {
         }
     }
 
+    Timer {
+        id: initialCheckTimer
+        interval: Math.max(SettingsData.systemUpdateInitialDelayMs, 0)
+        repeat: false
+        running: false
+        onTriggered: checkForUpdates()
+    }
+
     function checkForUpdates() {
+        if (initialCheckTimer.running)
+            initialCheckTimer.stop()
         if (!distributionSupported || !pkgManager || isChecking) return
 
         isChecking = true


### PR DESCRIPTION
## Summary
- add a settings-backed delay for the first automatic system update refresh
- defer the helper-triggered update check until after the configurable timer fires
- keep manual triggers and the periodic refresh logic working after the deferred run

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db1d57c704832d82c64bf3996ad278